### PR TITLE
Make project Python2 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ cache: pip
 matrix:
   fast_finish: true
   include:
+    - python: 2.7
+      env: TOXENV=py27-django111-drf37
+
     - python: 3.4
       env: TOXENV=py34-django111-drf37
     - python: 3.4

--- a/rest_polymorphic/serializers.py
+++ b/rest_polymorphic/serializers.py
@@ -1,5 +1,4 @@
 from collections import Mapping
-from pprint import pprint
 
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models

--- a/rest_polymorphic/serializers.py
+++ b/rest_polymorphic/serializers.py
@@ -1,4 +1,5 @@
 from collections import Mapping
+from pprint import pprint
 
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models
@@ -23,10 +24,10 @@ class PolymorphicSerializer(serializers.Serializer):
                     cls=cls.__name__
                 )
             )
-        return super().__new__(cls, *args, **kwargs)
+        return super(PolymorphicSerializer, cls).__new__(cls, *args, **kwargs)
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super(PolymorphicSerializer, self).__init__(*args, **kwargs)
 
         model_serializer_mapping = self.model_serializer_mapping
         self.model_serializer_mapping = {}

--- a/rest_polymorphic/serializers.py
+++ b/rest_polymorphic/serializers.py
@@ -1,4 +1,5 @@
 from collections import Mapping
+from six import string_types
 
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models
@@ -17,7 +18,7 @@ class PolymorphicSerializer(serializers.Serializer):
                     cls=cls.__name__
                 )
             )
-        if not isinstance(cls.resource_type_field_name, str):
+        if not isinstance(cls.resource_type_field_name, string_types):
             raise ImproperlyConfigured(
                 '`{cls}.resource_type_field_name` must be a string'.format(
                     cls=cls.__name__

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(
         'django',
         'djangorestframework',
         'django-polymorphic',
+        'six',
     ],
     classifiers=[
         # Trove classifiers

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist =
+    py27-django111-drf37
     {py34,py35,py36,py37}-django{111,20}-drf37,
     py{35,36,37}-djangomaster-drf37
     flake8
@@ -8,6 +9,7 @@ envlist =
 [testenv]
 passenv = CI TRAVIS TRAVIS_*
 basepython =
+    py27: python2.7
     py34: python3.4
     py35: python3.5
     py36: python3.6


### PR DESCRIPTION
This simple commit performs syntax changes to make the project work in Python 2. This is fully backwards compatible.

EDIT: Made a second commit removing an unnecessary pprint import