### PR TITLE
Allow None if the field is marked as allow_null = True

### DIFF
--- a/rest_polymorphic/serializers.py
+++ b/rest_polymorphic/serializers.py
@@ -92,6 +92,11 @@ class PolymorphicSerializer(serializers.Serializer):
         return valid and child_valid
     
     def run_validation(self, data=empty):
+        
+        if self.allow_null and data is None:
+            # If allow_null is present, allow None as valid
+            return None
+        
         resource_type = self._get_resource_type_from_mapping(data)
         serializer = self._get_serializer_from_resource_type(resource_type)
         validated_data = serializer.run_validation(data)


### PR DESCRIPTION
Continuing with the example of the documentation

```
class ProjectPolymorphicSerializer(PolymorphicSerializer):
    model_serializer_mapping = {
        Project: ProjectSerializer,
        ArtProject: ArtProjectSerializer,
        ResearchProject: ResearchProjectSerializer
    }
```
if we try to use this serializer in another model:

For example:

# model.py
```
class Question(models.Model):
    question = models.CharField(max_length=240)
    project = models.ForeignKey("Project", null=True, blank=True, on_delete=models.PROTECT)
```
# serializer.py
```
class QuestionSerializer(serializers.ModelSerializer):
    project = ProjectPolymorphicSerializer(allow_null=True)
    class Meta:
        model = Question
        fields = ("pk", "question", "project")
```

Before this fix, the code will break