### PR TITLE
Drop python35 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,6 @@ cache: pip
 matrix:
   fast_finish: true
   include:
-    - python: 3.5
-      env: TOXENV=py35-django22-drf38
-    - python: 3.5
-      env: TOXENV=py35-django22-drf39
-    - python: 3.5
-      env: TOXENV=py35-django22-drf310
-    - python: 3.5
-      env: TOXENV=py35-django22-drf311
-
     - python: 3.6
       env: TOXENV=py36-django22-drf38
     - python: 3.6

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,6 @@ setup(
         'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.0',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',


### PR DESCRIPTION
Python 3.5 has reached EOL a few days ago, and therefore it can be deleted from test matrix.

Additionally I am thinking about adding type annotations and mypy for testing, but I am not sure whether it should go in this PR.

Any comments are welcome.