### PR TITLE
Add `child_kwargs` to PolymorphicSerializer

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -13,3 +13,4 @@ Contributors
 * Jeff Hackshaw <jeffrey.hackshaw@gmail.com>
 * TFranzel
 * Ignacio Losiggio <iglosiggio@gmail.com>
+* Nick Sarbicki <nick.a.sarbicki@gmail.com>

--- a/README.rst
+++ b/README.rst
@@ -190,3 +190,29 @@ Now, the request for creating new object will look like this:
 .. code-block:: bash
 
     $ http POST "http://localhost:8000/projects/" projecttype="artproject" topic="Guernica" artist="Picasso"
+
+
+Pass additional keyword arguments to child serializers
+------------------------------------------------------
+
+It is also possible to pass extra keyword arguments intended only for the child serializers. For instance a child serializer using `Flex Fields <https://github.com/rsinger86/drf-flex-fields>`_.
+
+With serializers such as:
+
+.. code-block:: python
+
+    class SomeModelFlexSerializer(FlexFieldsModelSerializer):
+        class Meta:
+            model = SomeModel
+
+
+    class ProjectPolymorphicSerializer(PolymorphicSerializer):
+        model_serializer_mapping = {
+            SomeModel: SomeModelFlexSerializer
+        }
+
+Extra keyword arguments could be passed to the child serializer like so:
+
+.. code-block::python
+
+    ProjectPolymorphicSerializer(data, child_kwargs={"omit": ["field_name"]})

--- a/rest_polymorphic/serializers.py
+++ b/rest_polymorphic/serializers.py
@@ -27,17 +27,18 @@ class PolymorphicSerializer(serializers.Serializer):
             )
         return super(PolymorphicSerializer, cls).__new__(cls, *args, **kwargs)
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, child_kwargs=None, **kwargs):
         super(PolymorphicSerializer, self).__init__(*args, **kwargs)
 
         model_serializer_mapping = self.model_serializer_mapping
         self.model_serializer_mapping = {}
         self.resource_type_model_mapping = {}
+        child_kwargs = child_kwargs or {}
 
         for model, serializer in model_serializer_mapping.items():
             resource_type = self.to_resource_type(model)
             if callable(serializer):
-                serializer = serializer(*args, **kwargs)
+                serializer = serializer(*args, **child_kwargs, **kwargs)
                 serializer.parent = self
 
             self.resource_type_model_mapping[resource_type] = model
@@ -90,7 +91,7 @@ class PolymorphicSerializer(serializers.Serializer):
             child_valid = serializer.is_valid(*args, **kwargs)
             self._errors.update(serializer.errors)
         return valid and child_valid
-    
+
     def run_validation(self, data=empty):
         resource_type = self._get_resource_type_from_mapping(data)
         serializer = self._get_serializer_from_resource_type(resource_type)

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -147,9 +147,23 @@ class TestPolymorphicSerializer:
 
         data['slug'] = 'test-blog-slug-new'
         duplicate = BlogPolymorphicSerializer(data=data)
-        
+
         assert not duplicate.is_valid()
         assert 'non_field_errors' in duplicate.errors
         err = duplicate.errors['non_field_errors']
 
         assert err == ['The fields info, about must make a unique set.']
+
+    def test_extra_kwargs_applied(self):
+        data = {
+            'name': 'test-blog',
+            'slug': 'test-blog-slug',
+            'info': 'test-blog-info',
+            'resourcetype': 'BlogThree'
+        }
+
+        serializer = BlogPolymorphicSerializer(data=data, child_kwargs={"partial": True})
+
+        assert not serializer.partial
+        for child in serializer.model_serializer_mapping.values():
+            assert child.partial


### PR DESCRIPTION
This enables passing in a dictionary param, `child_kwargs`, to
a PolymorphicSerializer. In doing so the `child_kwargs` will not
be applied to the Polymorphic Serializer - but will be applied to
the child serializers alongside `kwargs`.

This resolves issue #33 