### PR TITLE
Allow registering model / serializer mappings at app startup

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -13,3 +13,4 @@ Contributors
 * Jeff Hackshaw <jeffrey.hackshaw@gmail.com>
 * TFranzel
 * Ignacio Losiggio <iglosiggio@gmail.com>
+* Micah Yeager

--- a/README.rst
+++ b/README.rst
@@ -100,6 +100,41 @@ Then you have to create a polymorphic serializer that serves as a mapper between
             ResearchProject: ResearchProjectSerializer
         }
 
+Alternatively, you can create a polymorphic serializer with an empty mapping, then register the models and serializer mappings later (useful for including serializers from other apps):
+
+.. code-block:: python
+
+    # serializers.py
+    from rest_polymorphic.serializers import PolymorphicSerializer
+
+
+    class ProjectPolymorphicSerializer(PolymorphicSerializer):
+        model_serializer_mapping = {}
+
+.. code-block:: python
+
+    # apps.py
+    from django.apps import AppConfig
+
+
+    class MyAppConfig(AppConfig):
+        name = 'myapp'
+
+        def ready(self):
+            # place the imports and registrations here, so they're only ever called once
+            from .serializers import ProjectSerializer, ArtProjectSerializer, ResearchProjectSerializer
+            from .models import Project, ArtProject, ResearchProject
+
+            ProjectPolymorphicSerializer.register_model_serializer_mapping(
+                Project, ProjectSerializer
+            )
+            ProjectPolymorphicSerializer.register_model_serializer_mapping(
+                ArtProject, ArtProjectSerializer
+            )
+            ProjectPolymorphicSerializer.register_model_serializer_mapping(
+                ResearchProject, ResearchProjectSerializer
+            )
+
 Create viewset with serializer_class equals to your polymorphic serializer:
 
 .. code-block:: python

--- a/rest_polymorphic/serializers.py
+++ b/rest_polymorphic/serializers.py
@@ -46,6 +46,12 @@ class PolymorphicSerializer(serializers.Serializer):
     # ----------
     # Public API
 
+    @classmethod
+    def register_model_serializer_mapping(cls, model, serializer):
+        """Register mapping between model and serializer."""
+
+        cls.model_serializer_mapping[model] = serializer
+
     def to_resource_type(self, model_or_instance):
         return model_or_instance._meta.object_name
 

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -4,8 +4,10 @@ import pytest
 
 from rest_polymorphic.serializers import PolymorphicSerializer
 
-from tests.models import BlogBase, BlogOne, BlogTwo
-from tests.serializers import BlogPolymorphicSerializer
+from tests.models import BlogBase, BlogOne, BlogTwo, BlogThree
+from tests.serializers import BlogPolymorphicSerializer, BlogBaseSerializer, \
+    BlogOneSerializer, BlogTwoSerializer, BlogThreeSerializer
+
 
 pytestmark = pytest.mark.django_db
 
@@ -40,6 +42,28 @@ class TestPolymorphicSerializer:
     def test_each_serializer_has_context(self, mocker):
         context = mocker.MagicMock()
         serializer = BlogPolymorphicSerializer(context=context)
+        for inner_serializer in serializer.model_serializer_mapping.values():
+            assert inner_serializer.context == context
+
+    def test_each_registered_serializer_has_context(self, mocker):
+        class RegisteredBlogPolymorphicSerializer(PolymorphicSerializer):
+            model_serializer_mapping = {}
+
+        RegisteredBlogPolymorphicSerializer.register_model_serializer_mapping(
+            BlogBase, BlogBaseSerializer
+        )
+        RegisteredBlogPolymorphicSerializer.register_model_serializer_mapping(
+            BlogOne, BlogOneSerializer
+        )
+        RegisteredBlogPolymorphicSerializer.register_model_serializer_mapping(
+            BlogTwo, BlogTwoSerializer
+        )
+        RegisteredBlogPolymorphicSerializer.register_model_serializer_mapping(
+            BlogThree, BlogThreeSerializer
+        )
+
+        context = mocker.MagicMock()
+        serializer = RegisteredBlogPolymorphicSerializer(context=context)
         for inner_serializer in serializer.model_serializer_mapping.values():
             assert inner_serializer.context == context
 


### PR DESCRIPTION
I encountered a situation where I had:

- a Django app with the base polymorphic model
- Django sub-apps that had models that inherited from the base polymorphic model

These Django sub-app models needed to to be able to registered with the base polymorphic model serializer, but I couldn't import them into the parent Django app serializers since not all sub-apps would necessarily be added to the `INSTALLED_APPS` list in `project/settings.py`.

This merge request allows the child polymorphic model serializers to be registered separately from the parent polymorphic model serializer definition, solving the issue I had above. It works since the Django Rest Framework serializers are instantiated when the API view is rendered, not at app initialization.